### PR TITLE
bug fix when creating a route using CAP + define route hostname for provider account

### DIFF
--- a/mta.yaml
+++ b/mta.yaml
@@ -17,6 +17,8 @@ modules:
     build-parameters:
       ignore: ["node_modules/"]
     parameters:
+      routes:
+      - route: ${org}-${app-name}.${default-domain}
       memory: 128M
       disk-quota: 2GB
       keep-existing-routes: true

--- a/srv/create-route.js
+++ b/srv/create-route.js
@@ -18,7 +18,7 @@ async function createRouteCAP(tenantHost, domain, uiAppName) {
     `&hosts=${tenantHost}`;
   LOG.info("urlFindRoute", urlFindRoute);
   const routeGetResult = await cfapi.get(urlFindRoute);
-  const routeGuid = routeGetResult?.resources[0].guid;
+  const routeGuid = routeGetResult?.resources[0]?.guid;
   LOG.info("Route GUID: ", routeGuid);
   if (routeGuid) {
     LOG.info("Route already exists");


### PR DESCRIPTION
Noticed that if the route didn't exists, it raises an error on the guid because the object is undefined

Second commit is for generating a correct route for the provider account to the approuter. Otherwise, it uses the space to generate a route which didn't worked correctly for me.